### PR TITLE
Add flag environment variables to the generated man panges

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -57,14 +57,18 @@ func addCommand(man *mango.ManPage, node *kong.Node, parent *mango.Command) {
 	}
 
 	for _, flag := range node.Flags {
+		help := flag.Help
 		short := ""
 		if flag.Short != 0 {
 			short = fmt.Sprintf("%c", flag.Short)
 		}
+		if flag.Env != "" {
+			help += fmt.Sprintf(" ($%s)", flag.Env)
+		}
 		item.AddFlag(mango.Flag{
 			Name:  strings.TrimPrefix(flag.Summary(), "--"),
 			Short: short,
-			Usage: flag.Help,
+			Usage: help,
 			PFlag: true,
 		})
 	}

--- a/example.1
+++ b/example.1
@@ -14,7 +14,7 @@ Destination directory\&.
 Show context-sensitive help\&.
 .TP
 \fB--log="debug"\fP
-Log level (debug,info,warn,error)\&.
+Log level (debug,info,warn,error)\&. ($EXAMPLE_DEBUG)
 .TP
 \fB--man\fP
 Print man page\&.

--- a/example/main.go
+++ b/example/main.go
@@ -8,7 +8,7 @@ import (
 var cli struct {
 	Man  mangokong.ManFlag `help:"Print man page."`
 	Dest string            `help:"Destination directory." placeholder:"DIR"`
-	Log  string            `help:"Log level (${enum})." enum:"debug,info,warn,error" default:"debug"`
+	Log  string            `help:"Log level (${enum})." enum:"debug,info,warn,error" default:"debug" env:"EXAMPLE_DEBUG"`
 
 	Info   InfoCmd   `cmd:"" help:"Info command."`
 	Delete DeleteCmd `cmd:"" help:"Delete command."`


### PR DESCRIPTION
Show flags environment variables if they exist. This is the default behavior when using Kong help flag, it adds any environment variables to the flag description.

![image](https://user-images.githubusercontent.com/3187948/182905198-53562786-406a-4e94-84c5-d6f1b3c6c2d2.png)
